### PR TITLE
Cálculo del tiempo que tarda una señal en viajar desde la Tierra a otros planetas

### DIFF
--- a/src/simuladorInterplanetario/SimuladorInterplanetario.java
+++ b/src/simuladorInterplanetario/SimuladorInterplanetario.java
@@ -428,5 +428,24 @@ public class SimuladorInterplanetario {
         naveFallandoOxigeno = false;
         reparacionesRealizadas = 0;
     }
+    
+    public static void calcularTiempoSenal() {
+    double velocidadLuz = 299792.458; // km/s
+
+    String[] planetas = {
+        "Mercurio", "Venus", "Marte", "Júpiter", "Saturno", "Urano", "Neptuno", "Plutón"
+    };
+    
+    double[] distancias = {
+        91.7, 41.4, 78.3, 628.7, 1275.0, 2721.0, 4351.0, 5869.7  // en millones de km
+    };
+
+    System.out.println("Tiempo que tarda una señal en llegar a cada planeta:");
+    for (int i = 0; i < planetas.length; i++) {
+        double tiempoSegundos = (distancias[i] * 1_000_000) / velocidadLuz;
+        double tiempoMinutos = tiempoSegundos / 60;
+        System.out.printf("- %s: %.2f minutos\n", planetas[i], tiempoMinutos);
+    }
+}
 
 }


### PR DESCRIPTION
Objetivo funcional:
Esta funcionalidad permite calcular y mostrar al usuario cuánto tiempo (en minutos) tarda una señal de radio, que viaja a la velocidad de la luz, en llegar desde la Tierra hasta distintos planetas del sistema solar, basándose en sus distancias promedio desde la Tierra.

La nueva función calcularTiempoSenal() realiza los siguientes pasos:
- Define un arreglo de planetas:
Incluye Mercurio, Venus, Marte, Júpiter, Saturno, Urano, Neptuno y Plutón.
- Define un arreglo paralelo con las distancias promedio desde la Tierra a cada planeta (en millones de kilómetros).
- Define la velocidad de la luz en el vacío: 299,792.458 km/s.
- Calcula, para cada planeta, el tiempo que tardaría una señal en viajar desde la Tierra: 
- Convierte la distancia a kilómetros reales (millones × 1,000,000).
- Usa la fórmula: tiempo = distancia / velocidad de la luz
- Convierte el resultado de segundos a minutos para una presentación más clara.
Se imprime una lista con el tiempo estimado, como este ejemplo:
Tiempo que tarda una señal en llegar a cada planeta:
- Mercurio: 5.10 minutos
- Venus: 2.30 minutos
- Marte: 4.35 minutos
...

¿Qué aporta al proyecto?
Esta función simula un fenómeno real del espacio (latencia en las comunicaciones espaciales), lo que:
- Enriquece el simulador interplanetario con datos científicos.
- Aporta una aplicación práctica de conceptos físicos.

